### PR TITLE
fix: slabs selling in different rooms

### DIFF
--- a/app/components/organisms/AddSlabDialog.tsx
+++ b/app/components/organisms/AddSlabDialog.tsx
@@ -54,12 +54,14 @@ export const AddSlabDialog = ({
   type SlabState = { id: number; bundle: string } | undefined
   const [selectedSlab, setSelectedSlab] = useState<SlabState>()
 
-  const allRooms = form.watch('rooms')
-  const addedSlabIds = allRooms.flatMap(room => room.slabs.map(slab => slab.id))
+  // Only exclude slabs that are already in the CURRENT room
+  // Allow the same slab to be selected for different rooms
+  const currentRoomSlabs = form.watch(`rooms.${roomIndex}.slabs`)
+  const currentRoomSlabIds = currentRoomSlabs.map(slab => slab.id)
 
   const { data = [] } = useQuery({
-    queryKey: ['slabs', stoneId, addedSlabIds],
-    queryFn: () => getSlabs(stoneId, addedSlabIds),
+    queryKey: ['slabs', stoneId, JSON.stringify(currentRoomSlabIds)],
+    queryFn: () => getSlabs(stoneId, currentRoomSlabIds),
     enabled: !!stoneId && show,
   })
 
@@ -74,6 +76,7 @@ export const AddSlabDialog = ({
         is_full: false,
       },
     ])
+    setSelectedSlab(undefined)
     setShow(false)
   }
 

--- a/app/components/organisms/RoomSubForm.tsx
+++ b/app/components/organisms/RoomSubForm.tsx
@@ -108,10 +108,28 @@ export const RoomSubForm = ({
   const [stone, setStone] = useState<StoneSlim | undefined>()
 
   useEffect(() => {
+    let isMounted = true
+
     if (slabIds.length > 0) {
-      getStone(slabIds[0]).then(setStone)
+      getStone(slabIds[0]).then((stone) => {
+        if (isMounted) setStone(stone)
+      })
+    } else {
+      // If current room has no slabs, try to get stone from first room
+      const allRooms = form.getValues('rooms')
+      const firstRoomWithSlabs = allRooms.find(room => room.slabs.length > 0)
+      if (firstRoomWithSlabs && firstRoomWithSlabs.slabs.length > 0) {
+        getStone(firstRoomWithSlabs.slabs[0].id).then((stone) => {
+          if (isMounted) setStone(stone)
+        })
+      }
     }
-  }, [JSON.stringify(slabIds)])
+
+    return () => {
+      isMounted = false
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slabIds.length, slabIds[0]])
 
   const { data: slabMap } = useQuery({
     queryKey: ['slabMap', slabIds],

--- a/app/orm/contract.ts
+++ b/app/orm/contract.ts
@@ -218,21 +218,22 @@ export class Contract {
     )
   }
 
-  protected async duplicateSlab(slabId: number) {
+  /**
+   * Creates a child slab (copy) of the parent slab and returns the new ID
+   * Used when a slab needs to be split (partial sales or multi-room usage)
+   */
+  protected async createChildSlab(parentSlabId: number): Promise<number> {
     const [slab] = await db.execute<RowDataPacket[]>(
       `SELECT length, width, stone_id, bundle, url FROM slab_inventory WHERE id = ?`,
-      [slabId],
+      [parentSlabId],
     )
-    if (slab.length > 1) {
-      return
-    }
-    if (!slab || slab.length === 0) {
-      return
+    if (slab.length === 0) {
+      throw new Error(`Slab with id ${parentSlabId} not found`)
     }
     const slabItem = slab[0]
-    await db.execute<ResultSetHeader>(
-      `INSERT INTO slab_inventory 
-                (stone_id, bundle, length, width, url, parent_id) 
+    const [result] = await db.execute<ResultSetHeader>(
+      `INSERT INTO slab_inventory
+                (stone_id, bundle, length, width, url, parent_id)
                 VALUES (?, ?, ?, ?, ?, ?)`,
       [
         slabItem.stone_id,
@@ -240,9 +241,25 @@ export class Contract {
         slabItem.length,
         slabItem.width,
         slabItem.url,
-        slabId,
+        parentSlabId,
       ],
     )
+    return result.insertId
+  }
+
+  /**
+   * Legacy method: creates a child slab for partial sales (is_full = false)
+   * Calls createChildSlab but ignores the returned ID
+   */
+  protected async duplicateSlab(slabId: number) {
+    const [slab] = await db.execute<RowDataPacket[]>(
+      `SELECT id FROM slab_inventory WHERE id = ?`,
+      [slabId],
+    )
+    if (slab.length > 1 || slab.length === 0) {
+      return
+    }
+    await this.createChildSlab(slabId)
   }
 
   protected async deleteDuplicateSlab(slabId: number) {
@@ -251,20 +268,79 @@ export class Contract {
 
   async sell(user: User) {
     this.saleId = await this.createSale(user)
-    for (const room of this.data.rooms) {
-      const firstSlab = room.slabs[0]
-      for (const slab of room.slabs) {
-        await this.sellSlab(slab.id, room)
 
-        if (!slab.is_full) {
-          await this.duplicateSlab(slab.id)
+    // Handle duplicate slabs: if a slab is used in multiple rooms, create child slabs
+    const slabUsageMap = new Map<number, number>() // slabId -> usage count
+    const slabReplacementMap = new Map<string, number>() // roomIndex-slabIndex -> new slabId
+
+    // Count slab usage across all rooms
+    this.data.rooms.forEach((room) => {
+      room.slabs.forEach((slab) => {
+        const count = slabUsageMap.get(slab.id) || 0
+        slabUsageMap.set(slab.id, count + 1)
+      })
+    })
+
+    // Create child slabs for duplicates
+    for (let roomIndex = 0; roomIndex < this.data.rooms.length; roomIndex++) {
+      const room = this.data.rooms[roomIndex]
+      for (let slabIndex = 0; slabIndex < room.slabs.length; slabIndex++) {
+        const slab = room.slabs[slabIndex]
+        const usageCount = slabUsageMap.get(slab.id) || 0
+
+        // If this slab is used more than once, we need child slabs
+        if (usageCount > 1) {
+          // Get current usage index for this slab
+          const previousUsages = []
+          for (let r = 0; r < roomIndex; r++) {
+            previousUsages.push(
+              ...this.data.rooms[r].slabs.filter(s => s.id === slab.id),
+            )
+          }
+          for (let s = 0; s < slabIndex; s++) {
+            if (room.slabs[s].id === slab.id) {
+              previousUsages.push(room.slabs[s])
+            }
+          }
+
+          // If this is not the first usage, create a child slab
+          if (previousUsages.length > 0) {
+            const childSlabId = await this.createChildSlab(slab.id)
+            slabReplacementMap.set(`${roomIndex}-${slabIndex}`, childSlabId)
+          }
         }
       }
+    }
+
+    // Now sell slabs with replacements applied
+    for (let roomIndex = 0; roomIndex < this.data.rooms.length; roomIndex++) {
+      const room = this.data.rooms[roomIndex]
+
+      if (room.slabs.length === 0) {
+        throw new Error(`Room ${roomIndex + 1} has no slabs. At least one slab is required per room.`)
+      }
+
+      const firstSlab = room.slabs[0]
+      const firstSlabId =
+        slabReplacementMap.get(`${roomIndex}-0`) || firstSlab.id
+
+      for (let slabIndex = 0; slabIndex < room.slabs.length; slabIndex++) {
+        const slab = room.slabs[slabIndex]
+        const actualSlabId =
+          slabReplacementMap.get(`${roomIndex}-${slabIndex}`) || slab.id
+
+        await this.sellSlab(actualSlabId, room)
+
+        if (!slab.is_full) {
+          await this.duplicateSlab(actualSlabId)
+        }
+      }
+
       for (const sinkType of room.sink_type) {
-        await this.sellSink(firstSlab.id, sinkType.type_id, sinkType.price)
+        await this.sellSink(firstSlabId, sinkType.type_id, sinkType.price)
       }
       for (const faucetType of room.faucet_type) {
-        await this.sellFaucet(firstSlab.id, faucetType.type_id, faucetType.price)
+        await this.sellFaucet(firstSlabId, faucetType.type_id, faucetType.price)
       }
     }
     return this.saleId
@@ -275,11 +351,20 @@ export class Contract {
       throw new Error('Sale not found')
     }
     await this.deleteSale()
+
+    // First, unsell all slabs and their associated sinks/faucets
     for (const room of this.data.rooms) {
       for (const slab of room.slabs) {
         await this.unsellSlab(slab.id)
         await this.unsellSink(slab.id)
         await this.unsellFaucet(slab.id)
+      }
+    }
+
+    // Then, delete child slabs (partial slabs)
+    // We need to delete children after unselling to avoid deleting slabs before processing them
+    for (const room of this.data.rooms) {
+      for (const slab of room.slabs) {
         if (!slab.is_full) {
           await this.deleteDuplicateSlab(slab.id)
         }
@@ -295,37 +380,93 @@ export class Contract {
     await this.updateSale(user)
     await this.unsellSlabs(this.saleId)
 
-    for (const room of this.data.rooms) {
+    // Handle duplicate slabs: if a slab is used in multiple rooms, create child slabs
+    const slabUsageMap = new Map<number, number>() // slabId -> usage count
+    const slabReplacementMap = new Map<string, number>() // roomIndex-slabIndex -> new slabId
+
+    // Count slab usage across all rooms
+    this.data.rooms.forEach((room) => {
+      room.slabs.forEach((slab) => {
+        const count = slabUsageMap.get(slab.id) || 0
+        slabUsageMap.set(slab.id, count + 1)
+      })
+    })
+
+    // Create child slabs for duplicates
+    for (let roomIndex = 0; roomIndex < this.data.rooms.length; roomIndex++) {
+      const room = this.data.rooms[roomIndex]
+      for (let slabIndex = 0; slabIndex < room.slabs.length; slabIndex++) {
+        const slab = room.slabs[slabIndex]
+        const usageCount = slabUsageMap.get(slab.id) || 0
+
+        // If this slab is used more than once, we need child slabs
+        if (usageCount > 1) {
+          // Get current usage index for this slab
+          const previousUsages = []
+          for (let r = 0; r < roomIndex; r++) {
+            previousUsages.push(
+              ...this.data.rooms[r].slabs.filter(s => s.id === slab.id),
+            )
+          }
+          for (let s = 0; s < slabIndex; s++) {
+            if (room.slabs[s].id === slab.id) {
+              previousUsages.push(room.slabs[s])
+            }
+          }
+
+          // If this is not the first usage, create a child slab
+          if (previousUsages.length > 0) {
+            const childSlabId = await this.createChildSlab(slab.id)
+            slabReplacementMap.set(`${roomIndex}-${slabIndex}`, childSlabId)
+          }
+        }
+      }
+    }
+
+    // Now update slabs with replacements applied
+    for (let roomIndex = 0; roomIndex < this.data.rooms.length; roomIndex++) {
+      const room = this.data.rooms[roomIndex]
+
+      if (room.slabs.length === 0) {
+        throw new Error(`Room ${roomIndex + 1} has no slabs. At least one slab is required per room.`)
+      }
+
       const firstSlab = room.slabs[0]
+      const firstSlabId =
+        slabReplacementMap.get(`${roomIndex}-0`) || firstSlab.id
 
-      for (const slab of room.slabs) {
-        await this.unsellSink(slab.id)
-        await this.unsellFaucet(slab.id)
+      for (let slabIndex = 0; slabIndex < room.slabs.length; slabIndex++) {
+        const slab = room.slabs[slabIndex]
+        const actualSlabId =
+          slabReplacementMap.get(`${roomIndex}-${slabIndex}`) || slab.id
 
-        await this.updateSlab(slab.id, room)
+        await this.unsellSink(actualSlabId)
+        await this.unsellFaucet(actualSlabId)
+
+        await this.updateSlab(actualSlabId, room)
 
         const [hasChildren] = await db.execute<RowDataPacket[]>(
           `SELECT id FROM slab_inventory WHERE parent_id = ?`,
-          [slab.id],
+          [actualSlabId],
         )
 
         if (!slab.is_full) {
           if (hasChildren.length === 0) {
-            await this.duplicateSlab(slab.id)
+            await this.duplicateSlab(actualSlabId)
           }
         } else {
           if (hasChildren.length > 0) {
-            await this.deleteDuplicateSlab(slab.id)
+            await this.deleteDuplicateSlab(actualSlabId)
           }
         }
       }
 
       // Sell sinks and faucets **once per room**, associated with the first slab
       for (const sinkType of room.sink_type) {
-        await this.sellSink(firstSlab.id, sinkType.type_id, sinkType.price)
+        await this.sellSink(firstSlabId, sinkType.type_id, sinkType.price)
       }
       for (const faucetType of room.faucet_type) {
-        await this.sellFaucet(firstSlab.id, faucetType.type_id, faucetType.price)
+        await this.sellFaucet(firstSlabId, faucetType.type_id, faucetType.price)
       }
     }
   }


### PR DESCRIPTION
**app/components/organisms/AddSlabDialog.tsx**

- Фильтруются только слэбы из текущей комнаты (не из всех)
- Разрешён выбор одного слэба для разных комнат

**app/components/organisms/RoomSubForm.tsx**

- Автоматическое копирование stone из первой комнаты
- Исправлены memory leaks

**app/orm/contract.ts**

- sell(): Создание child slabs при повторном использовании слэба
- edit(): Создание child slabs при редактировании + проверка пустых комнат
- unsell(): Исправлен порядок операций (сначала unsell, потом удаление child slabs)
- Рефакторинг createChildSlab() и duplicateSlab()