### PR TITLE
Feat/fixes and email improvemets

### DIFF
--- a/app/components/EmailChat.tsx
+++ b/app/components/EmailChat.tsx
@@ -1,22 +1,36 @@
+import { useQuery } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import DOMPurify from 'isomorphic-dompurify'
 import {
+  Check,
   FileText,
   ImageIcon,
   MoreVertical,
   Package,
   PaperclipIcon,
   Pencil,
+  Search,
   SendIcon,
   Sparkles,
   Upload,
 } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { AttachmentImagePicker } from '~/components/AttachmentImagePicker'
 import { AiImproveButton } from '~/components/molecules/AiImproveButton'
 import { CustomDropdownMenu } from '~/components/molecules/DropdownMenu'
+import { EmailTemplatePickerPopover } from '~/components/molecules/EmailTemplatePickerPopover'
 import { LoadingButton } from '~/components/molecules/LoadingButton'
 import { SuperCarousel } from '~/components/organisms/SuperCarousel'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '~/components/ui/alert-dialog'
 import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
 import {
@@ -25,6 +39,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '~/components/ui/dialog'
+import { Input } from '~/components/ui/input'
 import {
   Select,
   SelectContent,
@@ -41,7 +56,23 @@ import {
 import { useIsMobile } from '~/hooks/use-mobile'
 import { useToast } from '~/hooks/use-toast'
 import { cn } from '~/lib/utils'
+import type { Nullable } from '~/types/utils'
 import { dateClass, fileSize } from '~/utils/constants'
+import {
+  type EmailTemplate,
+  fetchAllTemplates,
+  filterTemplates,
+  getTemplatePreview,
+  TEMPLATE_STALE_TIME,
+  templateQueryKey,
+} from '~/utils/emailTemplates'
+import {
+  getUnfilledCustomVariables,
+  hasAnyVariables,
+  replaceTemplateVariables,
+  type TemplateVariableData,
+} from '~/utils/emailTemplateVariables'
+import { htmlToPlainText } from '~/utils/stringHelpers'
 
 export interface EmailChatAttachment {
   id: number
@@ -209,6 +240,83 @@ function getInitials(name: string): string {
   return trimmed.slice(0, 1).toUpperCase()
 }
 
+function MobileTemplatePicker({
+  open,
+  onOpenChange,
+  templates,
+  isLoading,
+  searchQuery,
+  onSearchChange,
+  onSelect,
+  activeTemplateId,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  templates: EmailTemplate[]
+  isLoading: boolean
+  searchQuery: string
+  onSearchChange: (query: string) => void
+  onSelect: (template: EmailTemplate) => void
+  activeTemplateId: Nullable<number>
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-w-md rounded-xl'>
+        <DialogHeader>
+          <DialogTitle>Choose Template</DialogTitle>
+        </DialogHeader>
+        <div className='relative'>
+          <Search className='absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400' />
+          <Input
+            placeholder='Search templates...'
+            value={searchQuery}
+            onChange={e => onSearchChange(e.target.value)}
+            className='pl-8 text-sm'
+          />
+        </div>
+        <div className='max-h-64 overflow-y-auto -mx-2'>
+          {isLoading && (
+            <div className='flex items-center justify-center py-4'>
+              <div className='animate-spin h-4 w-4 border-2 border-blue-500 rounded-full border-t-transparent' />
+            </div>
+          )}
+          {!isLoading && templates.length === 0 && (
+            <div className='px-3 py-4 text-sm text-gray-500 text-center'>
+              {searchQuery.length > 0 ? 'No templates found' : 'No templates available'}
+            </div>
+          )}
+          {!isLoading &&
+            templates.map(template => {
+              const isActive = template.id === activeTemplateId
+              return (
+                <button
+                  key={template.id}
+                  type='button'
+                  className={`w-full px-3 py-2 cursor-pointer text-left transition-colors ${
+                    isActive ? 'bg-blue-50' : 'hover:bg-gray-50'
+                  }`}
+                  onClick={() => onSelect(template)}
+                >
+                  <div className='flex items-center justify-between gap-2'>
+                    <div className='font-medium text-sm truncate'>
+                      {template.template_name}
+                    </div>
+                    {isActive && (
+                      <Check className='h-3.5 w-3.5 shrink-0 text-blue-600' />
+                    )}
+                  </div>
+                  <div className='text-xs text-gray-500 truncate'>
+                    {getTemplatePreview(template.template_body, 50)}...
+                  </div>
+                </button>
+              )
+            })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 export function EmailChat(props: EmailChatProps) {
   const { variant, customerName, messages, onClose } = props
 
@@ -218,7 +326,7 @@ export function EmailChat(props: EmailChatProps) {
   const [currentImages, setCurrentImages] = useState<
     { id: number; url: string; name: string; type: string; available: null }[]
   >([])
-  const [currentImageId, setCurrentImageId] = useState<number | null>(null)
+  const [currentImageId, setCurrentImageId] = useState<Nullable<number>>(null)
 
   const isEmployee = variant === 'employee'
   const employeeProps = isEmployeeProps(props) ? props : null
@@ -235,8 +343,39 @@ export function EmailChat(props: EmailChatProps) {
   const [showStonesPicker, setShowStonesPicker] = useState(false)
   const [showImagesPicker, setShowImagesPicker] = useState(false)
   const [showDocumentsPicker, setShowDocumentsPicker] = useState(false)
+  const [showMobileTemplatePicker, setShowMobileTemplatePicker] = useState(false)
+  const [mobileTemplateSearch, setMobileTemplateSearch] = useState('')
+  const [pendingTemplate, setPendingTemplate] = useState<Nullable<EmailTemplate>>(null)
+  const [activeTemplateId, setActiveTemplateId] = useState<Nullable<number>>(null)
   const { toast } = useToast()
   const isMobile = useIsMobile()
+
+  const { data: mobileTemplates = [], isLoading: mobileTemplatesLoading } = useQuery({
+    queryKey: templateQueryKey(employeeProps?.companyId ?? 0),
+    queryFn: () => fetchAllTemplates(employeeProps?.companyId ?? 0),
+    enabled: showMobileTemplatePicker && !!employeeProps?.companyId,
+    staleTime: TEMPLATE_STALE_TIME,
+  })
+
+  const { data: templateVariableData } = useQuery({
+    queryKey: ['templateVariables', employeeProps?.dealId],
+    queryFn: async () => {
+      const params = new URLSearchParams()
+      if (employeeProps?.dealId) {
+        params.set('dealId', String(employeeProps.dealId))
+      }
+      const res = await fetch(`/api/template-variables?${params}`)
+      if (!res.ok) return {}
+      return res.json() as Promise<TemplateVariableData>
+    },
+    enabled: !!employeeProps,
+    staleTime: TEMPLATE_STALE_TIME,
+  })
+
+  const filteredMobileTemplates = useMemo(
+    () => filterTemplates(mobileTemplates, mobileTemplateSearch),
+    [mobileTemplates, mobileTemplateSearch],
+  )
 
   useEffect(() => {
     setChatMessages(messages)
@@ -342,12 +481,49 @@ export function EmailChat(props: EmailChatProps) {
     handleGenerate(value)
   }
 
+  const applyEmailTemplate = (template: EmailTemplate) => {
+    if (!employeeProps) return
+
+    const variableData: TemplateVariableData = templateVariableData ?? {}
+    const replaced = replaceTemplateVariables(template.template_body, variableData)
+    const plainText = htmlToPlainText(replaced)
+    setMessageText(plainText)
+    setActiveTemplateId(template.id)
+
+    const customVars = getUnfilledCustomVariables(plainText)
+    if (customVars.length > 0) {
+      toast({
+        title: 'Custom variables detected',
+        description: `Please fill in: ${customVars.map(v => `{{${v}}}`).join(', ')}`,
+      })
+    }
+  }
+
+  const handleEmailTemplateSelect = (template: EmailTemplate): boolean => {
+    if (!employeeProps) return false
+    if (messageText.trim() !== '') {
+      setPendingTemplate(template)
+      return false
+    }
+    applyEmailTemplate(template)
+    return true
+  }
+
+  const handleConfirmTemplateReplace = () => {
+    if (!pendingTemplate) return
+    applyEmailTemplate(pendingTemplate)
+    setPendingTemplate(null)
+    setShowMobileTemplatePicker(false)
+    setMobileTemplateSearch('')
+  }
+
   const handleGenerate = async (templateOverride?: string) => {
     if (!employeeProps) return
     const template = templateOverride || selectedTemplate
     if (!template) return
     setIsGenerating(true)
     setMessageText('')
+    setActiveTemplateId(null)
     try {
       await generateAIEmailForChat(
         template,
@@ -367,10 +543,21 @@ export function EmailChat(props: EmailChatProps) {
     }
   }
 
+  const unfilled = useMemo(() => getUnfilledCustomVariables(messageText), [messageText])
+
   const handleSend = async () => {
     if (!employeeProps) return
     const body = messageText.trim()
     if (!body && attachments.length === 0) return
+    if (hasAnyVariables(body)) {
+      toast({
+        title: 'Placeholders detected',
+        description:
+          'Please replace all {{placeholders}} with actual values before sending',
+        variant: 'destructive',
+      })
+      return
+    }
     if (!employeeProps.customerEmail) {
       alert('Customer email is missing')
       return
@@ -439,6 +626,7 @@ export function EmailChat(props: EmailChatProps) {
       ])
       setMessageText('')
       setAttachments([])
+      setActiveTemplateId(null)
       toast({ title: 'Success', description: 'Email sent!', variant: 'success' })
     } catch (error) {
       if (error instanceof Error) {
@@ -712,6 +900,21 @@ export function EmailChat(props: EmailChatProps) {
               })}
             </div>
           )}
+          {isEmployee && unfilled.length > 0 && (
+            <div className='mb-2 p-2.5 text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded-md'>
+              <p>
+                <strong>Action required:</strong> Please replace the following
+                placeholders with actual values before sending:
+              </p>
+              <ul className='mt-1 list-disc list-inside'>
+                {unfilled.map(variable => (
+                  <li key={variable}>
+                    <code className='bg-amber-100 px-1 rounded'>{`{{${variable}}}`}</code>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
           {isEmployee && employeeProps ? (
             <div className='flex flex-col md:flex-row flex-1 gap-2'>
               <div className='hidden md:flex items-end gap-2'>
@@ -801,6 +1004,11 @@ export function EmailChat(props: EmailChatProps) {
                               ]
                             : []),
                           {
+                            label: 'Use Template',
+                            icon: <FileText className='w-4 h-4' />,
+                            onClick: () => setShowMobileTemplatePicker(true),
+                          },
+                          {
                             label: 'Generate with AI',
                             icon: <Sparkles className='w-4 h-4' />,
                             onClick: () => {
@@ -824,7 +1032,7 @@ export function EmailChat(props: EmailChatProps) {
                   />
                 </div>
 
-                <div className='hidden md:block'>
+                <div className='hidden md:flex items-end gap-1'>
                   {employeeProps.companyId > 0 ? (
                     <CustomDropdownMenu
                       side='top'
@@ -869,6 +1077,11 @@ export function EmailChat(props: EmailChatProps) {
                       <PaperclipIcon className='h-5 w-5' />
                     </Button>
                   )}
+                  <EmailTemplatePickerPopover
+                    companyId={employeeProps.companyId}
+                    onSelect={handleEmailTemplateSelect}
+                    activeTemplateId={activeTemplateId}
+                  />
                 </div>
 
                 <input
@@ -890,6 +1103,7 @@ export function EmailChat(props: EmailChatProps) {
                   value={messageText}
                   onChange={e => {
                     setMessageText(e.target.value)
+                    setActiveTemplateId(null)
                     if (textareaRef.current) {
                       textareaRef.current.style.height = 'auto'
                       textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`
@@ -967,6 +1181,48 @@ export function EmailChat(props: EmailChatProps) {
             />
           </>
         )}
+        {isEmployee && employeeProps && (
+          <MobileTemplatePicker
+            open={showMobileTemplatePicker}
+            onOpenChange={open => {
+              setShowMobileTemplatePicker(open)
+              if (!open) setMobileTemplateSearch('')
+            }}
+            templates={filteredMobileTemplates}
+            isLoading={mobileTemplatesLoading}
+            searchQuery={mobileTemplateSearch}
+            onSearchChange={setMobileTemplateSearch}
+            onSelect={template => {
+              const applied = handleEmailTemplateSelect(template)
+              if (applied) {
+                setShowMobileTemplatePicker(false)
+                setMobileTemplateSearch('')
+              }
+            }}
+            activeTemplateId={activeTemplateId}
+          />
+        )}
+        <AlertDialog
+          open={!!pendingTemplate}
+          onOpenChange={open => {
+            if (!open) setPendingTemplate(null)
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Replace message</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will replace your current message with the template. Continue?
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={handleConfirmTemplateReplace}>
+                Replace
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </DialogContent>
       <SuperCarousel
         type='email'

--- a/app/components/atoms/QuillEditor.tsx
+++ b/app/components/atoms/QuillEditor.tsx
@@ -38,6 +38,7 @@ export function QuillEditor({ value, onChange, onFilesDrop }: IQuillEditorProps)
       const currentContent = quill.root.innerHTML
       if (currentContent !== value && value !== undefined) {
         quill.clipboard.dangerouslyPasteHTML(value)
+        quill.setSelection(quill.getLength(), 0)
       }
     }
     isInternalChange.current = false

--- a/app/components/molecules/EmailTemplatePickerPopover.tsx
+++ b/app/components/molecules/EmailTemplatePickerPopover.tsx
@@ -1,0 +1,250 @@
+import { useQuery } from '@tanstack/react-query'
+import { Check, FileText, Search, X } from 'lucide-react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Button } from '~/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '~/components/ui/tooltip'
+import type { Nullable } from '~/types/utils'
+import {
+  type EmailTemplate,
+  fetchAllTemplates,
+  filterTemplates,
+  getTemplatePreview,
+  TEMPLATE_STALE_TIME,
+  templateQueryKey,
+} from '~/utils/emailTemplates'
+
+interface EmailTemplatePickerPopoverProps {
+  companyId: number
+  onSelect: (template: EmailTemplate) => void
+  activeTemplateId?: Nullable<number>
+}
+
+interface TemplateItemProps {
+  template: EmailTemplate
+  isHighlighted: boolean
+  isActive: boolean
+  onSelect: (template: EmailTemplate) => void
+  onMouseEnter: () => void
+}
+
+const TemplateItem = memo(function TemplateItem({
+  template,
+  isHighlighted,
+  isActive,
+  onSelect,
+  onMouseEnter,
+}: TemplateItemProps) {
+  const previewText = getTemplatePreview(template.template_body)
+
+  return (
+    <li
+      className={`px-3 py-2.5 cursor-pointer transition-colors ${
+        isActive ? 'bg-blue-50' : isHighlighted ? 'bg-gray-50' : 'hover:bg-gray-50'
+      }`}
+      onMouseDown={() => onSelect(template)}
+      onMouseEnter={onMouseEnter}
+    >
+      <div className='flex items-center justify-between gap-2'>
+        <div className='font-medium text-sm truncate'>{template.template_name}</div>
+        {isActive && <Check className='h-3.5 w-3.5 shrink-0 text-blue-600' />}
+      </div>
+      <div className='text-xs text-gray-400 truncate mt-0.5'>{previewText}</div>
+    </li>
+  )
+})
+
+export function EmailTemplatePickerPopover({
+  companyId,
+  onSelect,
+  activeTemplateId,
+}: EmailTemplatePickerPopoverProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [highlightedIndex, setHighlightedIndex] = useState(-1)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const listRef = useRef<HTMLUListElement>(null)
+  const isKeyboardNav = useRef(false)
+
+  const { data: allTemplates = [], isLoading } = useQuery({
+    queryKey: templateQueryKey(companyId),
+    queryFn: () => fetchAllTemplates(companyId),
+    enabled: isOpen,
+    staleTime: TEMPLATE_STALE_TIME,
+  })
+
+  const filteredTemplates = useMemo(
+    () => filterTemplates(allTemplates, searchQuery),
+    [allTemplates, searchQuery],
+  )
+
+  const close = useCallback(() => {
+    setIsOpen(false)
+    setSearchQuery('')
+    setHighlightedIndex(-1)
+  }, [])
+
+  const handleSelect = useCallback(
+    (template: EmailTemplate) => {
+      onSelect(template)
+      close()
+    },
+    [onSelect, close],
+  )
+
+  useEffect(() => {
+    setHighlightedIndex(-1)
+  }, [searchQuery])
+
+  const showSearch = allTemplates.length > 4
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        close()
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isOpen, close])
+
+  useEffect(() => {
+    if (isOpen) {
+      requestAnimationFrame(() => {
+        if (inputRef.current) {
+          inputRef.current.focus()
+        } else {
+          dropdownRef.current?.focus()
+        }
+      })
+    }
+  }, [isOpen, showSearch])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const count = filteredTemplates.length
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        close()
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        isKeyboardNav.current = true
+        setHighlightedIndex(prev => (prev < count - 1 ? prev + 1 : 0))
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        isKeyboardNav.current = true
+        setHighlightedIndex(prev => (prev > 0 ? prev - 1 : count - 1))
+      } else if (e.key === 'Enter' && highlightedIndex >= 0) {
+        e.preventDefault()
+        const template = filteredTemplates[highlightedIndex]
+        if (template) handleSelect(template)
+      }
+    },
+    [filteredTemplates, highlightedIndex, handleSelect, close],
+  )
+
+  useEffect(() => {
+    if (!isKeyboardNav.current || highlightedIndex < 0 || !listRef.current) return
+    const items = listRef.current.querySelectorAll('li')
+    items[highlightedIndex]?.scrollIntoView({ block: 'nearest' })
+    isKeyboardNav.current = false
+  }, [highlightedIndex])
+
+  return (
+    <div ref={containerRef} className='relative'>
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type='button'
+              size='icon'
+              variant='ghost'
+              aria-label='Use template'
+              onClick={() => (isOpen ? close() : setIsOpen(true))}
+            >
+              <FileText className='h-5 w-5' />
+            </Button>
+          </TooltipTrigger>
+          {!isOpen && <TooltipContent side='top'>Templates</TooltipContent>}
+        </Tooltip>
+      </TooltipProvider>
+
+      {isOpen && (
+        <div
+          ref={dropdownRef}
+          className='absolute bottom-full mb-1 left-0 z-50 w-80 bg-white border border-gray-200 rounded-lg shadow-lg outline-none'
+          onKeyDown={handleKeyDown}
+          tabIndex={-1}
+        >
+          <div className='flex items-center justify-between px-3 py-2 border-b border-gray-100'>
+            <span className='text-xs font-semibold text-gray-500 uppercase tracking-wide'>
+              Templates
+            </span>
+            <button
+              type='button'
+              className='text-gray-400 hover:text-gray-600 transition-colors'
+              onMouseDown={close}
+            >
+              <X className='h-3.5 w-3.5' />
+            </button>
+          </div>
+
+          {showSearch && (
+            <div className='p-2 border-b border-gray-100'>
+              <div className='relative'>
+                <Search className='absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400' />
+                <input
+                  ref={inputRef}
+                  type='text'
+                  placeholder='Search...'
+                  value={searchQuery}
+                  onChange={e => setSearchQuery(e.target.value)}
+                  className='w-full pl-7 pr-3 py-1.5 border border-gray-200 rounded text-sm outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500'
+                />
+              </div>
+            </div>
+          )}
+
+          <ul
+            ref={listRef}
+            className='max-h-52 overflow-y-auto divide-y divide-gray-100'
+          >
+            {isLoading && (
+              <li className='flex items-center justify-center py-6'>
+                <div className='animate-spin h-4 w-4 border-2 border-blue-500 rounded-full border-t-transparent' />
+              </li>
+            )}
+
+            {!isLoading && filteredTemplates.length === 0 && (
+              <li className='px-3 py-6 text-sm text-gray-400 text-center'>
+                {searchQuery.length > 0
+                  ? 'No templates found'
+                  : 'No templates available'}
+              </li>
+            )}
+
+            {!isLoading &&
+              filteredTemplates.map((template, index) => (
+                <TemplateItem
+                  key={template.id}
+                  template={template}
+                  isHighlighted={index === highlightedIndex}
+                  isActive={template.id === activeTemplateId}
+                  onSelect={handleSelect}
+                  onMouseEnter={() => setHighlightedIndex(index)}
+                />
+              ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/components/molecules/EmailTemplatePickerPopover.tsx
+++ b/app/components/molecules/EmailTemplatePickerPopover.tsx
@@ -166,7 +166,6 @@ export function EmailTemplatePickerPopover({
             <Button
               type='button'
               size='icon'
-              variant='ghost'
               aria-label='Use template'
               onClick={() => (isOpen ? close() : setIsOpen(true))}
             >

--- a/app/components/molecules/EmailTemplateSearch.tsx
+++ b/app/components/molecules/EmailTemplateSearch.tsx
@@ -1,15 +1,16 @@
 import { useQuery } from '@tanstack/react-query'
 import { X } from 'lucide-react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { EmailTemplate } from '~/utils/emailTemplates'
+import {
+  fetchAllTemplates,
+  filterTemplates,
+  getTemplatePreview,
+  TEMPLATE_STALE_TIME,
+  templateQueryKey,
+} from '~/utils/emailTemplates'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
-
-export interface EmailTemplate {
-  id: number
-  template_name: string
-  template_subject: string
-  template_body: string
-}
 
 interface EmailTemplateSearchProps {
   companyId: number
@@ -26,7 +27,7 @@ const TemplateItem = memo(function TemplateItem({
   template,
   onSelect,
 }: TemplateItemProps) {
-  const previewText = template.template_body.replace(/<[^>]*>/g, '').slice(0, 50)
+  const previewText = getTemplatePreview(template.template_body, 50)
 
   return (
     <li
@@ -62,15 +63,6 @@ const DropdownList = memo(function DropdownList({
   )
 })
 
-const fetchAllTemplates = async (companyId: number) => {
-  const response = await fetch(`/api/email-templates/search/${companyId}`)
-  if (!response.ok) {
-    throw new Error('Failed to fetch templates')
-  }
-  const data = await response.json()
-  return data.templates as EmailTemplate[]
-}
-
 export function EmailTemplateSearch({
   companyId,
   value,
@@ -81,21 +73,16 @@ export function EmailTemplateSearch({
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const { data: allTemplates = [], isLoading } = useQuery({
-    queryKey: ['emailTemplates', companyId],
+    queryKey: templateQueryKey(companyId),
     queryFn: () => fetchAllTemplates(companyId),
     enabled: isOpen,
-    staleTime: 60000,
+    staleTime: TEMPLATE_STALE_TIME,
   })
 
-  const filteredTemplates = useMemo(() => {
-    const query = inputValue.trim().toLowerCase()
-    if (!query) return allTemplates
-    return allTemplates.filter(
-      t =>
-        t.template_name.toLowerCase().includes(query) ||
-        t.template_body.toLowerCase().includes(query),
-    )
-  }, [allTemplates, inputValue])
+  const filteredTemplates = useMemo(
+    () => filterTemplates(allTemplates, inputValue),
+    [allTemplates, inputValue],
+  )
 
   useEffect(() => {
     return () => {

--- a/app/routes/api.template-variables.ts
+++ b/app/routes/api.template-variables.ts
@@ -1,0 +1,30 @@
+import type { LoaderFunctionArgs } from 'react-router'
+import { fetchTemplateVariableData } from '~/services/templateVariables.server'
+import { posthogClient } from '~/utils/posthog.server'
+import { getEmployeeUser, type User } from '~/utils/session.server'
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  let user: User
+  try {
+    user = await getEmployeeUser(request)
+  } catch (error) {
+    posthogClient.captureException(error)
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const url = new URL(request.url)
+  const dealIdParam = url.searchParams.get('dealId')
+  const dealId = dealIdParam ? parseInt(dealIdParam, 10) : undefined
+
+  try {
+    const data = await fetchTemplateVariableData({
+      user,
+      dealId: dealId && !Number.isNaN(dealId) ? dealId : undefined,
+    })
+
+    return Response.json(data)
+  } catch (error) {
+    posthogClient.captureException(error)
+    return Response.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/routes/employee.customers.info.$customerId.info.tsx
+++ b/app/routes/employee.customers.info.$customerId.info.tsx
@@ -19,7 +19,6 @@ type CustomerInfo = {
 type DealRow = {
   id: number
   amount: number | null
-  title: string | null
   lost_reason: string | null
   list_name: string
   created_at: string | null
@@ -180,11 +179,6 @@ export default function CustomerInfoTab() {
                     </div>
                   )}
                 </div>
-                {d.title && (
-                  <div className='text-sm text-slate-600 mt-1 whitespace-pre-wrap'>
-                    <span className='font-semibold'>Title:</span> {d.title}
-                  </div>
-                )}
                 {d.lost_reason && (
                   <div className='text-sm text-slate-600 mt-1 whitespace-pre-wrap'>
                     <span className='font-semibold text-red-600'>Lost reason:</span>{' '}

--- a/app/routes/employee.customers.info.$customerId.tsx
+++ b/app/routes/employee.customers.info.$customerId.tsx
@@ -34,7 +34,6 @@ type CustomerInfo = {
 type DealRow = {
   id: number
   amount: number | null
-  title: string | null
   lost_reason: string | null
   list_name: string
   created_at: string | null
@@ -111,7 +110,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
 
   const deals = await selectMany<DealRow>(
     db,
-    `SELECT d.id, d.amount, d.title, d.lost_reason, l.name AS list_name, d.created_at
+    `SELECT d.id, d.amount, d.lost_reason, l.name AS list_name, d.created_at
      FROM deals d
      JOIN deals_list l ON l.id = d.list_id
      WHERE d.customer_id = ? AND d.deleted_at IS NULL AND l.deleted_at IS NULL

--- a/app/routes/employee.deals.edit.$dealId.project.email.tsx
+++ b/app/routes/employee.deals.edit.$dealId.project.email.tsx
@@ -34,10 +34,7 @@ import { z } from 'zod'
 import { AttachmentImagePicker } from '~/components/AttachmentImagePicker'
 import { AiImproveButton } from '~/components/molecules/AiImproveButton'
 import { CustomDropdownMenu } from '~/components/molecules/DropdownMenu'
-import {
-  type EmailTemplate,
-  EmailTemplateSearch,
-} from '~/components/molecules/EmailTemplateSearch'
+import { EmailTemplateSearch } from '~/components/molecules/EmailTemplateSearch'
 import { InputItem } from '~/components/molecules/InputItem'
 import { LoadingButton } from '~/components/molecules/LoadingButton'
 import { QuillInput } from '~/components/molecules/QuillInput'
@@ -78,6 +75,7 @@ import { useIsMobile } from '~/hooks/use-mobile'
 import { useToast } from '~/hooks/use-toast'
 import { useArrowCarousel } from '~/hooks/useArrowToggle'
 import { fetchTemplateVariableData } from '~/services/templateVariables.server'
+import type { EmailTemplate } from '~/utils/emailTemplates'
 import {
   getUnfilledCustomVariables,
   hasAnyVariables,

--- a/app/routes/employee.emails.sendEmail.tsx
+++ b/app/routes/employee.emails.sendEmail.tsx
@@ -34,10 +34,7 @@ import { z } from 'zod'
 import { AttachmentImagePicker } from '~/components/AttachmentImagePicker'
 import { AiImproveButton } from '~/components/molecules/AiImproveButton'
 import { CustomDropdownMenu } from '~/components/molecules/DropdownMenu'
-import {
-  type EmailTemplate,
-  EmailTemplateSearch,
-} from '~/components/molecules/EmailTemplateSearch'
+import { EmailTemplateSearch } from '~/components/molecules/EmailTemplateSearch'
 import { InputItem } from '~/components/molecules/InputItem'
 import { LoadingButton } from '~/components/molecules/LoadingButton'
 import { MultiEmailRecipientInput } from '~/components/molecules/MultiEmailRecipientInput'
@@ -70,6 +67,7 @@ import { db } from '~/db.server'
 import { useIsMobile } from '~/hooks/use-mobile'
 import { useToast } from '~/hooks/use-toast'
 import { fetchTemplateVariableData } from '~/services/templateVariables.server'
+import type { EmailTemplate } from '~/utils/emailTemplates'
 import {
   getUnfilledCustomVariables,
   replaceTemplateVariables,

--- a/app/services/templateVariables.server.ts
+++ b/app/services/templateVariables.server.ts
@@ -1,10 +1,11 @@
 import type { RowDataPacket } from 'mysql2'
 import { db } from '~/db.server'
+import type { Nullable } from '~/types/utils'
 import type { TemplateVariableData } from '~/utils/emailTemplateVariables'
 
 interface UserData {
   id: number
-  name?: string | null
+  name?: Nullable<string>
   email?: string
   phone_number?: string
   company_id?: number
@@ -22,7 +23,7 @@ export async function fetchTemplateVariableData({
   customerId,
 }: FetchTemplateVariableDataParams): Promise<TemplateVariableData> {
   const [customerData, companyData] = await Promise.all([
-    fetchCustomerData(dealId, customerId),
+    fetchCustomerData(dealId, customerId, user.company_id),
     fetchCompanyData(user.company_id),
   ])
 
@@ -40,6 +41,7 @@ export async function fetchTemplateVariableData({
 async function fetchCustomerData(
   dealId?: number,
   customerId?: number,
+  companyId?: number,
 ): Promise<TemplateVariableData['customer']> {
   if (!dealId && !customerId) {
     return undefined
@@ -50,8 +52,8 @@ async function fetchCustomerData(
       `SELECT c.name, c.address
        FROM deals d
        JOIN customers c ON d.customer_id = c.id
-       WHERE d.id = ? AND d.deleted_at IS NULL`,
-      [dealId],
+       WHERE d.id = ? AND d.deleted_at IS NULL AND c.company_id = ?`,
+      [dealId, companyId],
     )
 
     if (rows?.[0]) {
@@ -64,8 +66,8 @@ async function fetchCustomerData(
 
   if (customerId) {
     const [rows] = await db.execute<RowDataPacket[]>(
-      `SELECT name, address FROM customers WHERE id = ? AND deleted_at IS NULL`,
-      [customerId],
+      `SELECT name, address FROM customers WHERE id = ? AND deleted_at IS NULL AND company_id = ?`,
+      [customerId, companyId],
     )
 
     if (rows?.[0]) {

--- a/app/utils/emailTemplates.ts
+++ b/app/utils/emailTemplates.ts
@@ -1,0 +1,43 @@
+import { decodeHtmlEntities } from '~/utils/stringHelpers'
+
+export interface EmailTemplate {
+  id: number
+  template_name: string
+  template_subject: string
+  template_body: string
+}
+
+export const TEMPLATE_STALE_TIME = 60_000
+
+export const TEMPLATE_PREVIEW_LENGTH = 60
+
+export function templateQueryKey(companyId: number) {
+  return ['emailTemplates', companyId] as const
+}
+
+export function filterTemplates(
+  templates: EmailTemplate[],
+  query: string,
+): EmailTemplate[] {
+  const normalized = query.trim().toLowerCase()
+  if (!normalized) return templates
+  return templates.filter(
+    t =>
+      t.template_name.toLowerCase().includes(normalized) ||
+      t.template_body.toLowerCase().includes(normalized),
+  )
+}
+
+export function getTemplatePreview(body: string, length = TEMPLATE_PREVIEW_LENGTH) {
+  const stripped = body.replace(/<[^>]*>/g, '')
+  return decodeHtmlEntities(stripped).slice(0, length)
+}
+
+export async function fetchAllTemplates(companyId: number) {
+  const response = await fetch(`/api/email-templates/search/${companyId}`)
+  if (!response.ok) {
+    throw new Error('Failed to fetch templates')
+  }
+  const data = await response.json()
+  return data.templates as EmailTemplate[]
+}

--- a/app/utils/stringHelpers.ts
+++ b/app/utils/stringHelpers.ts
@@ -7,6 +7,40 @@ export function parseEmailAddress(raw: string | null | undefined): string {
 
 export const stripHtmlTags = (html: string): string => html.replace(/<[^>]*>/g, '')
 
+const ENTITY_MAP: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+  '&nbsp;': ' ',
+}
+
+const ENTITY_REGEX = /&(?:amp|lt|gt|quot|#39|nbsp|#\d+|#x[\da-fA-F]+);/g
+
+export function decodeHtmlEntities(text: string): string {
+  return text.replace(ENTITY_REGEX, match => {
+    if (ENTITY_MAP[match]) return ENTITY_MAP[match]
+    if (match.startsWith('&#x'))
+      return String.fromCodePoint(Number.parseInt(match.slice(3, -1), 16))
+    if (match.startsWith('&#'))
+      return String.fromCodePoint(Number.parseInt(match.slice(2, -1), 10))
+    return match
+  })
+}
+
+export function htmlToPlainText(html: string): string {
+  const text = stripHtmlTags(
+    html
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<\/p>/gi, '\n')
+      .replace(/<\/div>/gi, '\n'),
+  )
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+  return decodeHtmlEntities(text)
+}
+
 export const isEmptyRichText = (html: string): boolean => {
   if (!html?.trim()) return true
   if (html === '<p><br></p>') return true


### PR DESCRIPTION
- Add template picker dropdown (desktop) and dialog (mobile) to the EmailChat compose area, allowing employees to insert pre-built templates directly in the chat
- Create shared utils (emailTemplates.ts) for template type, constants, query helpers, filtering, and preview with HTML entity decoding
- Add API route (api.template-variables) for lazy template variable resolution with React Query caching
- Replace window.confirm with AlertDialog for template overwrite confirmation
- Add placeholder validation banner and send-blocking for unfilled {{variables}}
- Add company_id filter to templateVariables.server.ts for multi-tenant safety
- Add htmlToPlainText and decodeHtmlEntities to stringHelpers
- Fix QuillEditor cursor position after template paste
- Remove the old deal description from the customer information modal 